### PR TITLE
Fix code scanning alert no. 25: Sensitive server cookie exposed to the client

### DIFF
--- a/controllers/auth.controller.js
+++ b/controllers/auth.controller.js
@@ -124,8 +124,8 @@ async function login(req, res, next) {
     existingAccount.accountId,
     process.env.SECRET_KEY
   ).toString();
-  res.cookie("existingUserId", JSON.stringify(existingUserId), { httpOnly: true });
-  res.cookie("existingAccountId", JSON.stringify(existingAccountId), { httpOnly: true });
+  res.cookie("existingUserId", JSON.stringify(existingUserId), { httpOnly: true, secure: true });
+  res.cookie("existingAccountId", JSON.stringify(existingAccountId), { httpOnly: true, secure: true });
 
   res.redirect("/home");
 }

--- a/controllers/auth.controller.js
+++ b/controllers/auth.controller.js
@@ -124,8 +124,8 @@ async function login(req, res, next) {
     existingAccount.accountId,
     process.env.SECRET_KEY
   ).toString();
-  res.cookie("existingUserId", JSON.stringify(existingUserId));
-  res.cookie("existingAccountId", JSON.stringify(existingAccountId));
+  res.cookie("existingUserId", JSON.stringify(existingUserId), { httpOnly: true });
+  res.cookie("existingAccountId", JSON.stringify(existingAccountId), { httpOnly: true });
 
   res.redirect("/home");
 }


### PR DESCRIPTION
Fixes [https://github.com/AbdulGhani002/Bank-App/security/code-scanning/25](https://github.com/AbdulGhani002/Bank-App/security/code-scanning/25)

To fix the problem, we need to set the `httpOnly` flag on the `existingAccountId` cookie. This will ensure that the cookie is not accessible via client-side scripts, thereby mitigating the risk of XSS attacks. We will also set the `httpOnly` flag on the `existingUserId` cookie for consistency and added security.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
